### PR TITLE
feat: new entities (reboot button, WiFi power save, etc.)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    rev: v0.14.14
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/custom_components/tronbytassistant/__init__.py
+++ b/custom_components/tronbytassistant/__init__.py
@@ -55,6 +55,8 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.TIME,
     Platform.SELECT,
+    Platform.BUTTON,
+    Platform.TEXT,
 ]
 
 DATA_CONFIG = "config"
@@ -512,13 +514,19 @@ class TronbytCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
     def verify_ssl(self) -> bool:
         return self._verify_ssl
 
-    async def _async_update_data(self) -> list[dict[str, Any]]:
-        session = async_get_clientsession(self.hass, verify_ssl=self._verify_ssl)
-        endpoint = f"{self._base_url}/v0/devices"
+    def _get_api_headers(self, content_type: str | None = None) -> dict[str, str]:
         headers = {
             "Authorization": f"Bearer {self._token}",
             "Accept": "application/json",
         }
+        if content_type:
+            headers["Content-Type"] = content_type
+        return headers
+
+    async def _async_update_data(self) -> list[dict[str, Any]]:
+        session = async_get_clientsession(self.hass, verify_ssl=self._verify_ssl)
+        endpoint = f"{self._base_url}/v0/devices"
+        headers = self._get_api_headers()
         try:
             async with session.get(endpoint, headers=headers) as response:
                 if response.status == 401:
@@ -560,14 +568,34 @@ class TronbytCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
 
         return devices
 
+    async def async_reboot_device(self, deviceid: str) -> None:
+        session = async_get_clientsession(self.hass, verify_ssl=self._verify_ssl)
+        url = f"{self._base_url}/v0/devices/{deviceid}/reboot"
+        headers = self._get_api_headers()
+        async with session.post(url, headers=headers) as response:
+            if response.status != 200:
+                error = await response.text()
+                raise HomeAssistantError(f"Failed to reboot device {deviceid}: {error}")
+
+    async def async_update_firmware_settings(
+        self, deviceid: str, payload: dict[str, Any]
+    ) -> None:
+        session = async_get_clientsession(self.hass, verify_ssl=self._verify_ssl)
+        url = f"{self._base_url}/v0/devices/{deviceid}/update_firmware_settings"
+        headers = self._get_api_headers("application/json")
+        async with session.post(url, headers=headers, json=payload) as response:
+            if response.status != 200:
+                error = await response.text()
+                raise HomeAssistantError(
+                    f"Failed to update firmware settings for {deviceid}: {error}"
+                )
+
+        await self.async_request_refresh()
+
     async def async_patch_device(self, deviceid: str, payload: dict[str, Any]) -> None:
         session = async_get_clientsession(self.hass, verify_ssl=self._verify_ssl)
         url = f"{self._base_url}/v0/devices/{deviceid}"
-        headers = {
-            "Authorization": f"Bearer {self._token}",
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        }
+        headers = self._get_api_headers("application/json")
 
         async with session.patch(url, headers=headers, json=payload) as response:
             if response.status != 200:
@@ -587,11 +615,7 @@ class TronbytCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
     ) -> None:
         session = async_get_clientsession(self.hass, verify_ssl=self._verify_ssl)
         url = f"{self._base_url}/v0/devices/{deviceid}/installations/{installation_id}"
-        headers = {
-            "Authorization": f"Bearer {self._token}",
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        }
+        headers = self._get_api_headers("application/json")
 
         async with session.patch(url, headers=headers, json=payload) as response:
             if response.status != 200:
@@ -609,10 +633,7 @@ class TronbytCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self, session: aiohttp.ClientSession, deviceid: str
     ) -> list[dict[str, Any]]:
         url = f"{self._base_url}/v0/devices/{deviceid}/installations"
-        headers = {
-            "Authorization": f"Bearer {self._token}",
-            "Accept": "application/json",
-        }
+        headers = self._get_api_headers()
         async with session.get(url, headers=headers) as response:
             if response.status != 200:
                 error = await response.text()
@@ -677,6 +698,16 @@ class TronbytCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 "protocol_version": info.get("protocolVersion"),
                 "protocol_type": info.get("protocolType"),
                 "mac_address": info.get("macAddress"),
+                "ssid": info.get("ssid"),
+                "wifi_power_save": info.get("wifiPowerSave"),
+                "skip_display_version": info.get("skipDisplayVersion"),
+                "ap_mode": info.get("apMode"),
+                "prefer_ipv6": info.get("preferIPv6"),
+                "swap_colors": info.get("swapColors"),
+                "image_url": info.get("imageUrl"),
+                "hostname": info.get("hostname"),
+                "sntp_server": info.get("sntpServer"),
+                "syslog_addr": info.get("syslogAddr"),
             },
             "installations": installations if installations is not None else [],
         }

--- a/custom_components/tronbytassistant/button.py
+++ b/custom_components/tronbytassistant/button.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.entity import EntityCategory
+
+from .const import DATA_COORDINATOR, DOMAIN
+from .device import build_device_info
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = hass.data.get(DOMAIN, {}).get(DATA_COORDINATOR)
+    if coordinator is None or not coordinator.data:
+        return
+
+    entities: list[TronbytButton] = []
+    for device in coordinator.data:
+        device_id = device.get("id")
+        if device_id:
+            entities.append(TronbytButton(coordinator, device_id))
+
+    if entities:
+        async_add_entities(entities)
+
+
+class TronbytButton(CoordinatorEntity, ButtonEntity):
+    """Button to reboot the Tronbyt device."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "reboot_button"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_device_class = "restart"
+
+    def __init__(self, coordinator, device_id: str) -> None:
+        super().__init__(coordinator)
+        self._deviceid = device_id
+        self._attr_unique_id = f"tronbyt-reboot-{device_id}"
+
+    def _device(self) -> dict[str, Any] | None:
+        for device in self.coordinator.data or []:
+            if device.get("id") == self._deviceid:
+                return device
+        return None
+
+    @property
+    def available(self) -> bool:
+        return self._device() is not None
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        return build_device_info(self._device(), self._deviceid)
+
+    async def async_press(self) -> None:
+        await self.coordinator.async_reboot_device(self._deviceid)

--- a/custom_components/tronbytassistant/config_flow.py
+++ b/custom_components/tronbytassistant/config_flow.py
@@ -7,7 +7,7 @@ import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -22,6 +22,52 @@ USER_DATA_SCHEMA = vol.Schema(
 )
 
 
+async def validate_input(
+    hass: HomeAssistant, data: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from USER_DATA_SCHEMA with values provided by the user.
+    """
+    api_url = _normalize_base_url(data[CONF_API_URL])
+    token = data[CONF_TOKEN]
+    verify_ssl = data.get(CONF_VERIFY_SSL, True)
+
+    endpoint = f"{api_url}/v0/devices"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+
+    session = async_get_clientsession(hass, verify_ssl=verify_ssl)
+    try:
+        async with session.get(endpoint, headers=headers) as response:
+            if response.status == 401:
+                raise InvalidAuth
+            if response.status != 200:
+                raise CannotConnect
+            payload = await response.json()
+    except aiohttp.ClientError as err:
+        raise CannotConnect from err
+
+    devices = payload.get("devices") or []
+    if not devices:
+        raise NoDevicesFound
+
+    normalized: list[dict[str, Any]] = []
+    for item in devices:
+        device_id = item.get("id")
+        if not device_id:
+            continue
+        name = item.get("displayName") or device_id
+        normalized.append({"id": device_id, "name": name})
+
+    if not normalized:
+        raise NoDevicesFound
+
+    return normalized
+
+
 class TronbytAssistantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for TronbytAssistant."""
 
@@ -32,16 +78,12 @@ class TronbytAssistantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                api_url = _normalize_base_url(user_input[CONF_API_URL])
+                _normalize_base_url(user_input[CONF_API_URL])
             except ValueError:
                 errors["base"] = "invalid_url"
             else:
-                token = user_input[CONF_TOKEN]
-                verify_ssl = user_input.get(CONF_VERIFY_SSL, True)
                 try:
-                    devices = await self._async_fetch_devices(
-                        api_url, token, verify_ssl
-                    )
+                    devices = await validate_input(self.hass, user_input)
                 except CannotConnect:
                     errors["base"] = "cannot_connect"
                 except InvalidAuth:
@@ -51,17 +93,19 @@ class TronbytAssistantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     await self.async_set_unique_id(DOMAIN)
                     self._abort_if_unique_id_configured()
+                    
+                    api_url = _normalize_base_url(user_input[CONF_API_URL])
                     parsed = urlparse(api_url)
                     title = parsed.hostname or parsed.netloc or api_url
                     if not title and devices:
                         title = devices[0]["name"]
+                    
+                    if CONF_VERIFY_SSL not in user_input:
+                        user_input[CONF_VERIFY_SSL] = True
+
                     return self.async_create_entry(
                         title=title,
-                        data={
-                            CONF_API_URL: api_url,
-                            CONF_TOKEN: token,
-                            CONF_VERIFY_SSL: verify_ssl,
-                        },
+                        data=user_input,
                     )
 
         schema = self.add_suggested_values_to_schema(USER_DATA_SCHEMA, user_input)
@@ -74,18 +118,15 @@ class TronbytAssistantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, user_input: dict[str, Any]):
         try:
-            api_url = _normalize_base_url(user_input.get(CONF_API_URL))
+            _normalize_base_url(user_input.get(CONF_API_URL))
         except ValueError:
             return self.async_abort(reason="invalid_import")
 
-        token = user_input.get(CONF_TOKEN)
-        if not token:
+        if not user_input.get(CONF_TOKEN):
             return self.async_abort(reason="invalid_import")
 
-        verify_ssl = user_input.get(CONF_VERIFY_SSL, True)
-
         try:
-            await self._async_fetch_devices(api_url, token, verify_ssl)
+            await validate_input(self.hass, user_input)
         except InvalidAuth:
             return self.async_abort(reason="invalid_api_key")
         except NoDevicesFound:
@@ -95,51 +136,17 @@ class TronbytAssistantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         await self.async_set_unique_id(DOMAIN)
         self._abort_if_unique_id_configured()
+        
+        api_url = _normalize_base_url(user_input[CONF_API_URL])
+        user_input[CONF_API_URL] = api_url
+
+        if CONF_VERIFY_SSL not in user_input:
+            user_input[CONF_VERIFY_SSL] = True
+
         return self.async_create_entry(
             title=urlparse(api_url).hostname or urlparse(api_url).netloc or api_url,
-            data={
-                CONF_API_URL: api_url,
-                CONF_TOKEN: token,
-                CONF_VERIFY_SSL: verify_ssl,
-            },
+            data=user_input,
         )
-
-    async def _async_fetch_devices(
-        self, api_url: str, token: str, verify_ssl: bool
-    ) -> list[dict[str, Any]]:
-        endpoint = f"{api_url}/v0/devices"
-        headers = {
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/json",
-        }
-
-        session = async_get_clientsession(self.hass, verify_ssl=verify_ssl)
-        try:
-            async with session.get(endpoint, headers=headers) as response:
-                if response.status == 401:
-                    raise InvalidAuth
-                if response.status != 200:
-                    raise CannotConnect
-                payload = await response.json()
-        except aiohttp.ClientError as err:
-            raise CannotConnect from err
-
-        devices = payload.get("devices") or []
-        if not devices:
-            raise NoDevicesFound
-
-        normalized: list[dict[str, Any]] = []
-        for item in devices:
-            device_id = item.get("id")
-            if not device_id:
-                continue
-            name = item.get("displayName") or device_id
-            normalized.append({"id": device_id, "name": name})
-
-        if not normalized:
-            raise NoDevicesFound
-
-        return normalized
 
     @staticmethod
     @callback
@@ -156,7 +163,36 @@ class TronbytAssistantOptionsFlow(config_entries.OptionsFlow):
         self._config_entry = config_entry
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
-        return self.async_abort(reason="not_supported")
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                _normalize_base_url(user_input[CONF_API_URL])
+            except ValueError:
+                errors["base"] = "invalid_url"
+            else:
+                try:
+                    await validate_input(self.hass, user_input)
+                except CannotConnect:
+                    errors["base"] = "cannot_connect"
+                except InvalidAuth:
+                    errors["base"] = "invalid_api_key"
+                except NoDevicesFound:
+                    errors["base"] = "no_devices_found"
+                else:
+                    self.hass.config_entries.async_update_entry(
+                        self._config_entry, data=user_input
+                    )
+                    return self.async_create_entry(title="", data={})
+
+        current_config = self._config_entry.data
+        schema = self.add_suggested_values_to_schema(USER_DATA_SCHEMA, current_config)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=schema,
+            errors=errors,
+        )
 
 
 class CannotConnect(HomeAssistantError):

--- a/custom_components/tronbytassistant/select.py
+++ b/custom_components/tronbytassistant/select.py
@@ -46,6 +46,34 @@ SELECT_DESCRIPTIONS: tuple[TronbytSelectDescription, ...] = (
 )
 
 
+@dataclass(frozen=True)
+class TronbytConfigSelectDescription:
+    key: str
+    translation_key: str | None
+    icon: str | None
+    value_fn: Callable[[dict[str, Any]], int | None]
+    patch_key: str
+    options: dict[str, int]
+    entity_registry_enabled_default: bool = True
+    entity_category: EntityCategory | None = EntityCategory.CONFIG
+
+
+CONFIG_SELECT_DESCRIPTIONS: tuple[TronbytConfigSelectDescription, ...] = (
+    TronbytConfigSelectDescription(
+        key="wifi_power_save",
+        translation_key="wifi_power_save",
+        icon="mdi:wifi-cog",
+        value_fn=lambda device: (device.get("info") or {}).get("wifi_power_save"),
+        patch_key="wifiPowerSave",
+        options={
+            "off": 0,
+            "min": 1,
+            "max": 2,
+        },
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -55,13 +83,20 @@ async def async_setup_entry(
     if coordinator is None or not coordinator.data:
         return
 
-    entities: list[TronbytSelect] = []
+    entities: list[SelectEntity] = []
     for description in SELECT_DESCRIPTIONS:
         for device in coordinator.data:
             device_id = device.get("id")
             if device_id is None:
                 continue
             entities.append(TronbytSelect(coordinator, device_id, description))
+
+    for description in CONFIG_SELECT_DESCRIPTIONS:
+        for device in coordinator.data:
+            device_id = device.get("id")
+            if device_id is None:
+                continue
+            entities.append(TronbytConfigSelect(coordinator, device_id, description))
 
     if entities:
         async_add_entities(entities)
@@ -165,6 +200,68 @@ class TronbytSelect(CoordinatorEntity, SelectEntity):
     @property
     def unit_of_measurement(self) -> str | None:  # type: ignore[override]
         return None
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        return build_device_info(self._device(), self._deviceid)
+
+
+class TronbytConfigSelect(CoordinatorEntity, SelectEntity):
+    """Select entity for Tronbyt configuration settings."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator,
+        device_id: str,
+        description: TronbytConfigSelectDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self._description = description
+        self._deviceid = device_id
+        self._attr_unique_id = f"tronbyt-{description.key}-{device_id}"
+        self._attr_icon = description.icon
+        self._attr_translation_key = description.translation_key
+        self._attr_entity_registry_enabled_default = (
+            description.entity_registry_enabled_default
+        )
+        self._attr_entity_category = description.entity_category
+        self._attr_device_class = None
+
+    def _device(self) -> Optional[dict[str, Any]]:
+        for device in self.coordinator.data or []:
+            if device.get("id") == self._deviceid:
+                return device
+        return None
+
+    @property
+    def available(self) -> bool:
+        return self._device() is not None
+
+    @property
+    def options(self) -> list[str]:
+        return list(self._description.options.keys())
+
+    @property
+    def current_option(self) -> str | None:
+        device = self._device()
+        if not device:
+            return None
+        current_val = self._description.value_fn(device)
+        for label, val in self._description.options.items():
+            if val == current_val:
+                return label
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        value = self._description.options.get(option)
+        if value is None:
+            return
+        await self.coordinator.async_update_firmware_settings(
+            self._deviceid,
+            {self._description.patch_key: value},
+        )
 
     @property
     def device_info(self) -> dict[str, Any]:

--- a/custom_components/tronbytassistant/switch.py
+++ b/custom_components/tronbytassistant/switch.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -14,6 +15,49 @@ from .const import DATA_COORDINATOR, DOMAIN
 from .device import build_device_info
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TronbytSwitchDescription:
+    key: str
+    translation_key: str | None
+    icon: str | None
+    value_fn: Callable[[dict[str, Any]], bool | None]
+    patch_key: str
+    entity_registry_enabled_default: bool = True
+    entity_category: EntityCategory | None = EntityCategory.CONFIG
+
+
+SWITCH_DESCRIPTIONS: tuple[TronbytSwitchDescription, ...] = (
+    TronbytSwitchDescription(
+        key="skip_display_version",
+        translation_key="skip_display_version",
+        icon="mdi:counter",
+        value_fn=lambda device: (device.get("info") or {}).get("skip_display_version"),
+        patch_key="skipDisplayVersion",
+    ),
+    TronbytSwitchDescription(
+        key="ap_mode",
+        translation_key="ap_mode",
+        icon="mdi:access-point",
+        value_fn=lambda device: (device.get("info") or {}).get("ap_mode"),
+        patch_key="apMode",
+    ),
+    TronbytSwitchDescription(
+        key="prefer_ipv6",
+        translation_key="prefer_ipv6",
+        icon="mdi:ip-network",
+        value_fn=lambda device: (device.get("info") or {}).get("prefer_ipv6"),
+        patch_key="preferIPv6",
+    ),
+    TronbytSwitchDescription(
+        key="swap_colors",
+        translation_key="swap_colors",
+        icon="mdi:palette-swatch",
+        value_fn=lambda device: (device.get("info") or {}).get("swap_colors"),
+        patch_key="swapColors",
+    ),
+)
 
 
 async def async_setup_entry(
@@ -32,6 +76,9 @@ async def async_setup_entry(
         if not device_id:
             continue
         entities.append(TronbytNightModeSwitch(coordinator, device_id))
+
+        for description in SWITCH_DESCRIPTIONS:
+            entities.append(TronbytFirmwareSwitch(coordinator, device_id, description))
 
         for install in device.get("installations") or []:
             install_id = install.get("id")
@@ -170,3 +217,59 @@ class TronbytInstallationSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def device_info(self) -> dict[str, Any]:
         return build_device_info(self._device(), self._deviceid)
+
+
+class TronbytFirmwareSwitch(CoordinatorEntity, SwitchEntity):
+    """Switch for Tronbyt firmware settings."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator,
+        device_id: str,
+        description: TronbytSwitchDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self._description = description
+        self._deviceid = device_id
+        self._attr_unique_id = f"tronbyt-{description.key}-{device_id}"
+        self._attr_icon = description.icon
+        self._attr_translation_key = description.translation_key
+        self._attr_entity_registry_enabled_default = (
+            description.entity_registry_enabled_default
+        )
+        self._attr_entity_category = description.entity_category
+
+    def _device(self) -> dict[str, Any] | None:
+        for device in self.coordinator.data or []:
+            if device.get("id") == self._deviceid:
+                return device
+        return None
+
+    @property
+    def available(self) -> bool:
+        return self._device() is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        device = self._device()
+        if not device:
+            return None
+        return self._description.value_fn(device)
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        return build_device_info(self._device(), self._deviceid)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self.coordinator.async_update_firmware_settings(
+            self._deviceid,
+            {self._description.patch_key: True},
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.coordinator.async_update_firmware_settings(
+            self._deviceid,
+            {self._description.patch_key: False},
+        )

--- a/custom_components/tronbytassistant/text.py
+++ b/custom_components/tronbytassistant/text.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from homeassistant.components.text import TextEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DATA_COORDINATOR, DOMAIN
+from .device import build_device_info
+
+
+@dataclass(frozen=True)
+class TronbytTextDescription:
+    key: str
+    translation_key: str | None
+    icon: str | None
+    value_fn: Callable[[dict[str, Any]], str | None]
+    patch_key: str
+    entity_registry_enabled_default: bool = True
+    entity_category: EntityCategory | None = EntityCategory.CONFIG
+
+
+TEXT_DESCRIPTIONS: tuple[TronbytTextDescription, ...] = (
+    TronbytTextDescription(
+        key="ssid",
+        translation_key="ssid",
+        icon="mdi:wifi",
+        value_fn=lambda device: (device.get("info") or {}).get("ssid"),
+        patch_key="ssid",
+    ),
+    TronbytTextDescription(
+        key="image_url",
+        translation_key="image_url",
+        icon="mdi:image",
+        value_fn=lambda device: (device.get("info") or {}).get("image_url"),
+        patch_key="imageUrl",
+    ),
+    TronbytTextDescription(
+        key="hostname",
+        translation_key="hostname",
+        icon="mdi:rename-box",
+        value_fn=lambda device: (device.get("info") or {}).get("hostname"),
+        patch_key="hostname",
+    ),
+    TronbytTextDescription(
+        key="sntp_server",
+        translation_key="sntp_server",
+        icon="mdi:clock-time-four-outline",
+        value_fn=lambda device: (device.get("info") or {}).get("sntp_server"),
+        patch_key="sntpServer",
+    ),
+    TronbytTextDescription(
+        key="syslog_addr",
+        translation_key="syslog_addr",
+        icon="mdi:file-document-outline",
+        value_fn=lambda device: (device.get("info") or {}).get("syslog_addr"),
+        patch_key="syslogAddr",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = hass.data.get(DOMAIN, {}).get(DATA_COORDINATOR)
+    if coordinator is None or not coordinator.data:
+        return
+
+    entities: list[TronbytText] = []
+    for description in TEXT_DESCRIPTIONS:
+        for device in coordinator.data:
+            device_id = device.get("id")
+            if device_id is None:
+                continue
+            entities.append(TronbytText(coordinator, device_id, description))
+
+    if entities:
+        async_add_entities(entities)
+
+
+class TronbytText(CoordinatorEntity, TextEntity):
+    """Configurable text value backed by the Tronbyt API."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator,
+        device_id: str,
+        description: TronbytTextDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self._description = description
+        self._deviceid = device_id
+        self._attr_unique_id = f"tronbyt-{description.key}-{device_id}"
+        self._attr_icon = description.icon
+        self._attr_translation_key = description.translation_key
+        self._attr_entity_registry_enabled_default = (
+            description.entity_registry_enabled_default
+        )
+        self._attr_entity_category = description.entity_category
+
+    def _device(self) -> dict[str, Any] | None:
+        for device in self.coordinator.data or []:
+            if device.get("id") == self._deviceid:
+                return device
+        return None
+
+    @property
+    def available(self) -> bool:
+        return self._device() is not None
+
+    @property
+    def native_value(self) -> str | None:
+        device = self._device()
+        if not device:
+            return None
+        return self._description.value_fn(device)
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        return build_device_info(self._device(), self._deviceid)
+
+    async def async_set_value(self, value: str) -> None:
+        await self.coordinator.async_update_firmware_settings(
+            self._deviceid,
+            {self._description.patch_key: value},
+        )

--- a/custom_components/tronbytassistant/translations/de.json
+++ b/custom_components/tronbytassistant/translations/de.json
@@ -17,6 +17,11 @@
     }
   },
   "entity": {
+    "button": {
+      "reboot_button": {
+        "name": "Neu starten"
+      }
+    },
     "light": {
       "brightness": {
         "name": "Helligkeit"
@@ -44,6 +49,23 @@
         "name": "Dimmmodus-Beginn"
       }
     },
+    "text": {
+      "ssid": {
+        "name": "SSID"
+      },
+      "image_url": {
+        "name": "Bild-URL"
+      },
+      "hostname": {
+        "name": "Hostname"
+      },
+      "sntp_server": {
+        "name": "SNTP-Server"
+      },
+      "syslog_addr": {
+        "name": "Syslog-Adresse"
+      }
+    },
     "select": {
       "night_mode_app": {
         "name": "Nachtmodus-App",
@@ -56,6 +78,14 @@
         "state": {
           "none": "Keine"
         }
+      },
+      "wifi_power_save": {
+        "name": "WLAN-Energiesparmodus",
+        "state": {
+          "off": "Aus",
+          "min": "Minimum",
+          "max": "Maximum"
+        }
       }
     },
     "switch": {
@@ -64,6 +94,18 @@
       },
       "installation_switch": {
         "name": "Aktiviere {label}"
+      },
+      "skip_display_version": {
+        "name": "Display-Version überspringen"
+      },
+      "ap_mode": {
+        "name": "AP-Modus"
+      },
+      "prefer_ipv6": {
+        "name": "IPv6 bevorzugen"
+      },
+      "swap_colors": {
+        "name": "Farben vertauschen"
       }
     }
   }

--- a/custom_components/tronbytassistant/translations/en.json
+++ b/custom_components/tronbytassistant/translations/en.json
@@ -17,6 +17,11 @@
     }
   },
   "entity": {
+    "button": {
+      "reboot_button": {
+        "name": "Restart"
+      }
+    },
     "light": {
       "brightness": {
         "name": "Brightness"
@@ -44,6 +49,23 @@
         "name": "Dim Mode Start"
       }
     },
+    "text": {
+      "ssid": {
+        "name": "SSID"
+      },
+      "image_url": {
+        "name": "Image URL"
+      },
+      "hostname": {
+        "name": "Hostname"
+      },
+      "sntp_server": {
+        "name": "SNTP Server"
+      },
+      "syslog_addr": {
+        "name": "Syslog Address"
+      }
+    },
     "select": {
       "night_mode_app": {
         "name": "Night Mode App",
@@ -56,6 +78,14 @@
         "state": {
           "none": "None"
         }
+      },
+      "wifi_power_save": {
+        "name": "WiFi Power Save",
+        "state": {
+          "off": "Off",
+          "min": "Minimum",
+          "max": "Maximum"
+        }
       }
     },
     "switch": {
@@ -64,6 +94,18 @@
       },
       "installation_switch": {
         "name": "Enable {label}"
+      },
+      "skip_display_version": {
+        "name": "Skip Display Version"
+      },
+      "ap_mode": {
+        "name": "AP Mode"
+      },
+      "prefer_ipv6": {
+        "name": "Prefer IPv6"
+      },
+      "swap_colors": {
+        "name": "Swap Colors"
       }
     }
   }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 import voluptuous as vol
@@ -11,7 +11,6 @@ from custom_components.tronbytassistant.config_flow import (
     CannotConnect,
     InvalidAuth,
     NoDevicesFound,
-    TronbytAssistantConfigFlow,
     _normalize_base_url,
 )
 from custom_components.tronbytassistant.const import (
@@ -20,6 +19,8 @@ from custom_components.tronbytassistant.const import (
     CONF_VERIFY_SSL,
     DOMAIN,
 )
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
 def _get_suggested_value(schema: vol.Schema, field: str):
@@ -41,10 +42,9 @@ def _get_suggested_value(schema: vol.Schema, field: str):
 async def test_user_flow_success(hass):
     """Validate that a user initiated flow succeeds."""
     device_payload = [{"id": "961adee8", "name": "Living Room"}]
-    with patch.object(
-        TronbytAssistantConfigFlow,
-        "_async_fetch_devices",
-        AsyncMock(return_value=device_payload),
+    with patch(
+        "custom_components.tronbytassistant.config_flow.validate_input",
+        return_value=device_payload,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -79,10 +79,9 @@ async def test_user_flow_rejects_bad_url(hass):
 @pytest.mark.asyncio
 async def test_user_flow_invalid_auth(hass):
     """Ensure authentication errors are reported."""
-    with patch.object(
-        TronbytAssistantConfigFlow,
-        "_async_fetch_devices",
-        AsyncMock(side_effect=InvalidAuth),
+    with patch(
+        "custom_components.tronbytassistant.config_flow.validate_input",
+        side_effect=InvalidAuth,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -102,10 +101,9 @@ async def test_user_flow_invalid_auth(hass):
 @pytest.mark.asyncio
 async def test_user_flow_cannot_connect(hass):
     """Ensure connectivity errors are reported."""
-    with patch.object(
-        TronbytAssistantConfigFlow,
-        "_async_fetch_devices",
-        AsyncMock(side_effect=CannotConnect),
+    with patch(
+        "custom_components.tronbytassistant.config_flow.validate_input",
+        side_effect=CannotConnect,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -125,10 +123,9 @@ async def test_user_flow_cannot_connect(hass):
 @pytest.mark.asyncio
 async def test_user_flow_no_devices(hass):
     """Ensure the flow stops when no devices are returned."""
-    with patch.object(
-        TronbytAssistantConfigFlow,
-        "_async_fetch_devices",
-        AsyncMock(side_effect=NoDevicesFound),
+    with patch(
+        "custom_components.tronbytassistant.config_flow.validate_input",
+        side_effect=NoDevicesFound,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -148,10 +145,9 @@ async def test_user_flow_no_devices(hass):
 @pytest.mark.asyncio
 async def test_import_flow_success(hass):
     """Validate YAML import flow."""
-    with patch.object(
-        TronbytAssistantConfigFlow,
-        "_async_fetch_devices",
-        AsyncMock(return_value=[{"id": "961adee8", "name": "Living Room"}]),
+    with patch(
+        "custom_components.tronbytassistant.config_flow.validate_input",
+        return_value=[{"id": "961adee8", "name": "Living Room"}],
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -194,10 +190,9 @@ def test_config_flow_normalize_base_url():
 @pytest.mark.asyncio
 async def test_user_flow_preserves_verify_ssl_toggle(hass):
     """Ensure toggled SSL flag persists after an error."""
-    with patch.object(
-        TronbytAssistantConfigFlow,
-        "_async_fetch_devices",
-        AsyncMock(side_effect=CannotConnect),
+    with patch(
+        "custom_components.tronbytassistant.config_flow.validate_input",
+        side_effect=CannotConnect,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -214,3 +209,40 @@ async def test_user_flow_preserves_verify_ssl_toggle(hass):
     assert _get_suggested_value(schema, CONF_API_URL) == "https://example.com"
     assert _get_suggested_value(schema, CONF_TOKEN) == "secret"
     assert _get_suggested_value(schema, CONF_VERIFY_SSL) is False
+
+
+@pytest.mark.asyncio
+async def test_options_flow(hass):
+    """Test the options flow."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_URL: "https://example.com",
+            CONF_TOKEN: "old_token",
+            CONF_VERIFY_SSL: True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    with patch(
+        "custom_components.tronbytassistant.config_flow.validate_input",
+        return_value=[{"id": "dev1", "name": "Device 1"}],
+    ):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_API_URL: "https://new.example.com",
+                CONF_TOKEN: "new_token",
+                CONF_VERIFY_SSL: False,
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.data[CONF_API_URL] == "https://new.example.com"
+    assert entry.data[CONF_TOKEN] == "new_token"
+    assert entry.data[CONF_VERIFY_SSL] is False

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -14,6 +14,8 @@ from custom_components.tronbytassistant import number as number_mod
 from custom_components.tronbytassistant import select as select_mod
 from custom_components.tronbytassistant import switch as switch_mod
 from custom_components.tronbytassistant import time as time_mod
+from custom_components.tronbytassistant import button as button_mod
+from custom_components.tronbytassistant import text as text_mod
 from custom_components.tronbytassistant.__init__ import TronbytCoordinator
 from custom_components.tronbytassistant.const import DOMAIN
 
@@ -44,6 +46,16 @@ def device_payload() -> dict[str, Any]:
             "protocol_version": 1,
             "protocol_type": "WS",
             "mac_address": "cc:dd:ee:ff:00:11",
+            "ssid": "MyWiFi",
+            "wifi_power_save": 1,
+            "skip_display_version": True,
+            "ap_mode": False,
+            "prefer_ipv6": True,
+            "swap_colors": False,
+            "image_url": "http://img",
+            "hostname": "myhost",
+            "sntp_server": "pool.ntp.org",
+            "syslog_addr": "1.2.3.4",
         },
         "installations": [
             {"id": "477", "appID": "Custom Clock", "enabled": True},
@@ -249,4 +261,96 @@ async def test_installation_switch_toggles_installation(
     await entity.async_turn_off()
     coordinator.async_patch_installation.assert_awaited_once_with(
         "dev1", "217", {"enabled": False}
+    )
+
+
+@pytest.mark.asyncio
+async def test_reboot_button(coordinator: TronbytCoordinator):
+    """Test reboot button calls correct async method."""
+    entity = button_mod.TronbytButton(coordinator, "dev1")
+    coordinator.async_reboot_device = AsyncMock()
+    await entity.async_press()
+    coordinator.async_reboot_device.assert_awaited_once_with("dev1")
+
+
+def test_text_entity_values(coordinator: TronbytCoordinator):
+    """Test text entity values extraction."""
+    # SSID
+    entity = text_mod.TronbytText(
+        coordinator, "dev1", text_mod.TEXT_DESCRIPTIONS[0]
+    )
+    assert entity.native_value == "MyWiFi"
+
+    # ImageURL
+    entity = text_mod.TronbytText(
+        coordinator, "dev1", text_mod.TEXT_DESCRIPTIONS[1]
+    )
+    assert entity.native_value == "http://img"
+
+
+@pytest.mark.asyncio
+async def test_text_entity_update(coordinator: TronbytCoordinator):
+    """Test text entity update calls firmware settings."""
+    entity = text_mod.TronbytText(
+        coordinator, "dev1", text_mod.TEXT_DESCRIPTIONS[2] # Hostname
+    )
+    coordinator.async_update_firmware_settings = AsyncMock()
+
+    await entity.async_set_value("newhost")
+    coordinator.async_update_firmware_settings.assert_awaited_once_with(
+        "dev1", {"hostname": "newhost"}
+    )
+
+
+def test_firmware_switch_values(coordinator: TronbytCoordinator):
+    """Test firmware switch values extraction."""
+    # SkipDisplayVersion
+    entity = switch_mod.TronbytFirmwareSwitch(
+        coordinator, "dev1", switch_mod.SWITCH_DESCRIPTIONS[0]
+    )
+    assert entity.is_on is True
+
+    # APMode
+    entity = switch_mod.TronbytFirmwareSwitch(
+        coordinator, "dev1", switch_mod.SWITCH_DESCRIPTIONS[1]
+    )
+    assert entity.is_on is False
+
+
+@pytest.mark.asyncio
+async def test_firmware_switch_update(coordinator: TronbytCoordinator):
+    """Test firmware switch update calls firmware settings."""
+    entity = switch_mod.TronbytFirmwareSwitch(
+        coordinator, "dev1", switch_mod.SWITCH_DESCRIPTIONS[2] # PreferIPv6
+    )
+    coordinator.async_update_firmware_settings = AsyncMock()
+
+    await entity.async_turn_off()
+    coordinator.async_update_firmware_settings.assert_awaited_once_with(
+        "dev1", {"preferIPv6": False}
+    )
+
+
+def test_config_select_values(coordinator: TronbytCoordinator):
+    """Test config select (WifiPowerSave)."""
+    entity = select_mod.TronbytConfigSelect(
+        coordinator, "dev1", select_mod.CONFIG_SELECT_DESCRIPTIONS[0]
+    )
+    # device payload has 1 -> min
+    assert entity.current_option == "min"
+    assert "min" in entity.options
+    assert "off" in entity.options
+
+
+@pytest.mark.asyncio
+async def test_config_select_update(coordinator: TronbytCoordinator):
+    """Test config select update calls firmware settings."""
+    entity = select_mod.TronbytConfigSelect(
+        coordinator, "dev1", select_mod.CONFIG_SELECT_DESCRIPTIONS[0]
+    )
+    coordinator.async_update_firmware_settings = AsyncMock()
+
+    await entity.async_select_option("max")
+    coordinator.async_update_firmware_settings.assert_awaited_once_with(
+        "dev1", {"wifiPowerSave": 2}
     )


### PR DESCRIPTION
1. New Entities:
    * Button: Added a "Reboot Device" button.
    * Text: Added entities for SSID, Image URL, Hostname, SNTP Server, and Syslog Address.
    * Switch: Added entities for Skip Display Version, AP Mode, Prefer IPv6, and Swap Colors.
    * Select: Added "WiFi Power Save" with options Off, Minimum, and Maximum.
2. Options Flow: Implemented TronbytAssistantOptionsFlow to allow users to reconfigure the Server URL, API Key, and SSL verification settings.

Fixes https://github.com/tronbyt/TronbytAssistant/issues/13