### PR TITLE
chore: disable config entities by default

### DIFF
--- a/custom_components/tronbytassistant/select.py
+++ b/custom_components/tronbytassistant/select.py
@@ -70,6 +70,7 @@ CONFIG_SELECT_DESCRIPTIONS: tuple[TronbytConfigSelectDescription, ...] = (
             "min": 1,
             "max": 2,
         },
+        entity_registry_enabled_default=False,
     ),
 )
 

--- a/custom_components/tronbytassistant/switch.py
+++ b/custom_components/tronbytassistant/switch.py
@@ -35,6 +35,7 @@ SWITCH_DESCRIPTIONS: tuple[TronbytSwitchDescription, ...] = (
         icon="mdi:counter",
         value_fn=lambda device: (device.get("info") or {}).get("skip_display_version"),
         patch_key="skipDisplayVersion",
+        entity_registry_enabled_default=False,
     ),
     TronbytSwitchDescription(
         key="ap_mode",
@@ -42,6 +43,7 @@ SWITCH_DESCRIPTIONS: tuple[TronbytSwitchDescription, ...] = (
         icon="mdi:access-point",
         value_fn=lambda device: (device.get("info") or {}).get("ap_mode"),
         patch_key="apMode",
+        entity_registry_enabled_default=False,
     ),
     TronbytSwitchDescription(
         key="prefer_ipv6",
@@ -49,6 +51,7 @@ SWITCH_DESCRIPTIONS: tuple[TronbytSwitchDescription, ...] = (
         icon="mdi:ip-network",
         value_fn=lambda device: (device.get("info") or {}).get("prefer_ipv6"),
         patch_key="preferIPv6",
+        entity_registry_enabled_default=False,
     ),
     TronbytSwitchDescription(
         key="swap_colors",
@@ -56,6 +59,7 @@ SWITCH_DESCRIPTIONS: tuple[TronbytSwitchDescription, ...] = (
         icon="mdi:palette-swatch",
         value_fn=lambda device: (device.get("info") or {}).get("swap_colors"),
         patch_key="swapColors",
+        entity_registry_enabled_default=False,
     ),
 )
 

--- a/custom_components/tronbytassistant/text.py
+++ b/custom_components/tronbytassistant/text.py
@@ -32,6 +32,7 @@ TEXT_DESCRIPTIONS: tuple[TronbytTextDescription, ...] = (
         icon="mdi:wifi",
         value_fn=lambda device: (device.get("info") or {}).get("ssid"),
         patch_key="ssid",
+        entity_registry_enabled_default=False,
     ),
     TronbytTextDescription(
         key="image_url",
@@ -39,6 +40,7 @@ TEXT_DESCRIPTIONS: tuple[TronbytTextDescription, ...] = (
         icon="mdi:image",
         value_fn=lambda device: (device.get("info") or {}).get("image_url"),
         patch_key="imageUrl",
+        entity_registry_enabled_default=False,
     ),
     TronbytTextDescription(
         key="hostname",
@@ -46,6 +48,7 @@ TEXT_DESCRIPTIONS: tuple[TronbytTextDescription, ...] = (
         icon="mdi:rename-box",
         value_fn=lambda device: (device.get("info") or {}).get("hostname"),
         patch_key="hostname",
+        entity_registry_enabled_default=False,
     ),
     TronbytTextDescription(
         key="sntp_server",
@@ -53,6 +56,7 @@ TEXT_DESCRIPTIONS: tuple[TronbytTextDescription, ...] = (
         icon="mdi:clock-time-four-outline",
         value_fn=lambda device: (device.get("info") or {}).get("sntp_server"),
         patch_key="sntpServer",
+        entity_registry_enabled_default=False,
     ),
     TronbytTextDescription(
         key="syslog_addr",
@@ -60,6 +64,7 @@ TEXT_DESCRIPTIONS: tuple[TronbytTextDescription, ...] = (
         icon="mdi:file-document-outline",
         value_fn=lambda device: (device.get("info") or {}).get("syslog_addr"),
         patch_key="syslogAddr",
+        entity_registry_enabled_default=False,
     ),
 )
 


### PR DESCRIPTION
By default, TronbytAssistant creates too many entities. This PR disables config entities by default: skip_display_version, ap_mode, prefer_ipv6, swap_colors, ssid, image_url, hostname, sntp_server, syslog_addr, wifi_power_save.